### PR TITLE
Fix compilation on Apple OS X

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -33,7 +33,9 @@
 #define __INTERNAL_H
 
 #include <stdlib.h>
+#if !defined(__APPLE__)
 #include <malloc_np.h>
+#endif
 #include <time.h>
 
 #include "px.h"

--- a/src/px.h
+++ b/src/px.h
@@ -35,7 +35,9 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/param.h>
+#if !defined(__APPLE__)
 #include <malloc_np.h>
+#endif
 #include "c.h"
 
 /* keep debug messages? */


### PR DESCRIPTION
Fix compilation on OS X.   just including stdlib.h should take care of what malloc_np.h is intended to handle
